### PR TITLE
Move test-related dependencies to dev group in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,12 +16,6 @@ nh3 = "^0.2.20"
 fastapi = "^0.115.8"
 httpx = "^0.28.1"
 anyio = "^4.8.0"
-pytest-asyncio = "^0.25.3"
-pytest-tornasync = "^0.6.0.post2"
-pytest-trio = "^0.8.0"
-pytest-twisted = "^1.14.3"
-twisted = "^24.11.0"
-rich = "^13.9.4"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.0.0"
@@ -30,6 +24,12 @@ black = "^24.1.1"
 isort = "^5.13.2"
 mypy = "^1.8.0"
 ruff = "^0.2.1"
+pytest-asyncio = "^0.25.3"
+pytest-tornasync = "^0.6.0.post2"
+pytest-trio = "^0.8.0"
+pytest-twisted = "^1.14.3"
+twisted = "^24.11.0"
+rich = "^13.9.4"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
This pull request reorganizes dependencies in the `pyproject.toml` file, moving several testing and development-related dependencies from the main dependencies section to the `dev.dependencies` section under `[tool.poetry.group]`.



